### PR TITLE
Add dry-run mode and shared migration utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,105 @@
+# Tableau Server-to-Cloud Migration Toolkit
+
+Migrate data sources, workbooks, and subscriptions from Tableau Server to Tableau Cloud using the [Tableau Migration SDK](https://help.tableau.com/current/api/migration_sdk/en-us/).
+
+## What gets migrated
+
+| Content type | Script | Configurable |
+|---|---|---|
+| Data Sources | `content_migration.py` | Yes (`migration_scope`) |
+| Workbooks | `content_migration.py` | Yes (`migration_scope`) |
+| Subscriptions | `subscriptions/simple_subscription_migration.py` | - |
+
+Users, groups, and projects are **always skipped** — they must already exist in your Cloud site.
+
+## Prerequisites
+
+- Python 3.8+
+- [Tableau Migration SDK](https://pypi.org/project/tableau-migration/): `pip install tableau-migration`
+- A personal access token for both Server and Cloud
+- Users and projects pre-created in Tableau Cloud
+
+## Quick start
+
+### 1. Configure credentials
+
+```bash
+cp config.json.template config.json
+# Edit config.json with your actual values
+```
+
+See [SETUP_INSTRUCTIONS.md](SETUP_INSTRUCTIONS.md) for field-by-field guidance.
+
+### 2. Preview with dry run
+
+```bash
+# Works without the SDK installed
+python dry_run.py
+
+# Or preview through the migration scripts
+python content_migration.py --dry-run
+python subscriptions/simple_subscription_migration.py --dry-run
+```
+
+### 3. Run the migration
+
+```bash
+# Migrate data sources and workbooks
+python content_migration.py
+
+# Migrate subscriptions (run separately, after content)
+python subscriptions/simple_subscription_migration.py
+```
+
+## Configuration
+
+`config.json` fields:
+
+| Field | Description |
+|---|---|
+| `source.server_url` | Tableau Server URL |
+| `source.site_content_url` | Site name (empty string `""` for default site) |
+| `source.access_token_name` / `access_token` | Server PAT credentials |
+| `destination.pod_url` | Cloud pod URL (e.g. `https://10ax.online.tableau.com`) |
+| `destination.site_content_url` | Cloud site name |
+| `destination.access_token_name` / `access_token` | Cloud PAT credentials |
+| `default_content_owner` | Cloud email to own content when original owner is missing |
+| `default_email_domain` | Domain appended to bare usernames (e.g. `@yourcompany.com`) |
+| `migration_scope.data_sources` | `true`/`false` — migrate data sources (default: `true`) |
+| `migration_scope.workbooks` | `true`/`false` — migrate workbooks (default: `true`) |
+
+## Dry-run mode
+
+All three entry points support a preview mode that validates config and shows what would happen, without touching either server:
+
+```
+python dry_run.py                  # Config validation only (no SDK needed)
+python dry_run.py --connect        # Also verify credentials via SDK
+python content_migration.py --dry-run
+```
+
+## Project structure
+
+```
+content_migration.py               # Migrate data sources & workbooks
+dry_run.py                         # Standalone config validator
+migration_utils.py                 # Shared config, filters, mapping, reporting
+config.json.template               # Config template (safe to commit)
+subscriptions/
+  simple_subscription_migration.py # Migrate subscriptions only
+tests/                             # pytest suite (49 tests)
+docs/                              # Additional guides and reference
+```
+
+## Running tests
+
+```bash
+pip install pytest
+pytest tests/ -v
+```
+
+Tests run without the Tableau Migration SDK installed — stub base classes in `migration_utils.py` allow all pure-Python logic to be tested independently.
+
+## Security
+
+`config.json` contains sensitive credentials and is listed in `.gitignore`. Never commit it — only commit `config.json.template`.

--- a/SETUP_INSTRUCTIONS.md
+++ b/SETUP_INSTRUCTIONS.md
@@ -2,15 +2,15 @@
 
 ## What Gets Migrated
 
-This script migrates **ONLY**:
-- ✅ **Data Sources**
-- ✅ **Workbooks**
+By default, `content_migration.py` migrates:
+- ✅ **Data Sources** (configurable via `migration_scope`)
+- ✅ **Workbooks** (configurable via `migration_scope`)
 
-This script **DOES NOT** migrate:
+It **DOES NOT** migrate:
 - ❌ Users
 - ❌ Groups
 - ❌ Projects
-- ❌ Subscriptions
+- ❌ Subscriptions (use `subscriptions/simple_subscription_migration.py` instead)
 
 ## Prerequisites
 
@@ -45,7 +45,12 @@ Open `config.json` and replace the placeholder values:
     "access_token_name": "your-cloud-token-name",
     "access_token": "your-cloud-token-secret"
   },
-  "default_content_owner": "admin@yourcompany.com"
+  "default_content_owner": "admin@yourcompany.com",
+  "default_email_domain": "@yourcompany.com",
+  "migration_scope": {
+    "data_sources": true,
+    "workbooks": true
+  }
 }
 ```
 
@@ -54,6 +59,8 @@ Open `config.json` and replace the placeholder values:
 - `pod_url` for destination: Update the pod (10ax, 10ay, 10az, etc.) based on your Tableau Cloud instance
 - `site_content_url` for destination: Your Tableau Cloud site name (NOT the full URL)
 - `default_content_owner`: Email of a Cloud user who will own content when the original owner doesn't exist in Cloud
+- `default_email_domain`: The email domain appended to Server usernames that aren't already emails (e.g., `"@yourcompany.com"` turns `jsmith` into `jsmith@yourcompany.com`)
+- `migration_scope` (optional): Control which content types are migrated. Set `"data_sources": false` or `"workbooks": false` to exclude them. Defaults to both `true` if omitted
 
 ### 3. Verify your Tableau Cloud token
 

--- a/TableauMigrationPython/config.json.template
+++ b/TableauMigrationPython/config.json.template
@@ -10,5 +10,7 @@
     "site_content_url": "production",
     "access_token_name": "your-cloud-token-name",
     "access_token": "your-cloud-token-secret"
-  }
+  },
+  "default_content_owner": "admin@yourcompany.com",
+  "default_email_domain": "@yourcompany.com"
 }

--- a/TableauMigrationPython/requirements.txt
+++ b/TableauMigrationPython/requirements.txt
@@ -9,6 +9,9 @@ python-dotenv>=1.0.0
 
 # Python's built-in csv module is used for CSV parsing (no extra deps needed)
 
+# Testing
+pytest>=7.0.0
+
 # Optional: For enhanced CSV handling with pandas
 # Uncomment if you want to use pandas for complex CSV operations
 # pandas>=2.0.0

--- a/config.json.template
+++ b/config.json.template
@@ -11,5 +11,10 @@
     "access_token_name": "your-cloud-token-name",
     "access_token": "your-cloud-token-secret"
   },
-  "default_content_owner": "admin@yourcompany.com"
+  "default_content_owner": "admin@yourcompany.com",
+  "default_email_domain": "@yourcompany.com",
+  "migration_scope": {
+    "data_sources": true,
+    "workbooks": true
+  }
 }

--- a/content_migration.py
+++ b/content_migration.py
@@ -2,7 +2,13 @@
 Content Migration - Data Sources and Workbooks
 Migrates workbooks and data sources (including custom views).
 Skips users, projects, and subscriptions (handled by separate script).
+
+Usage:
+    python content_migration.py              # Run the migration
+    python content_migration.py --dry-run    # Preview without migrating
 """
+
+import argparse
 
 from tableau_migration import (
     Migrator,
@@ -13,6 +19,7 @@ from migration_utils import (
     load_config,
     validate_config,
     get_migration_scope,
+    print_dry_run_report,
     EmailDomainMapping,
     SkipUserMigration,
     SkipGroupMigration,
@@ -28,12 +35,16 @@ configure_logging()
 # MIGRATION
 # =============================================================================
 
-def migrate_content():
+def migrate_content(dry_run=False):
     """Migrate data sources and workbooks from Server to Cloud."""
 
     # Load and validate configuration
     config = load_config()
     if not config or not validate_config(config):
+        return
+
+    if dry_run:
+        print_dry_run_report(config)
         return
 
     # Get config values
@@ -122,4 +133,7 @@ def migrate_content():
 
 
 if __name__ == "__main__":
-    migrate_content()
+    parser = argparse.ArgumentParser(description="Migrate content from Tableau Server to Cloud.")
+    parser.add_argument("--dry-run", action="store_true", help="Preview migration without executing.")
+    args = parser.parse_args()
+    migrate_content(dry_run=args.dry_run)

--- a/content_migration.py
+++ b/content_migration.py
@@ -4,152 +4,24 @@ Migrates workbooks and data sources (including custom views).
 Skips users, projects, and subscriptions (handled by separate script).
 """
 
-import logging
-import json
-from pathlib import Path
 from tableau_migration import (
     Migrator,
     MigrationPlanBuilder,
-    TableauCloudUsernameMappingBase,
-    ContentFilterBase,
-    IUser,
-    IProject,
-    IGroup
+)
+from migration_utils import (
+    configure_logging,
+    load_config,
+    validate_config,
+    get_migration_scope,
+    EmailDomainMapping,
+    SkipUserMigration,
+    SkipGroupMigration,
+    SkipProjectMigration,
+    SkipDataSourceMigration,
+    SkipWorkbookMigration,
 )
 
-# Configure logging - show content migration progress but suppress verbose HTTP/retry logs
-logging.basicConfig(
-    level=logging.INFO,  # Allow INFO messages through
-    format='%(message)s'
-)
-
-# Silence the noisy loggers (HTTP requests, retries, etc.) but keep migration engine visible
-logging.getLogger('System.Net.Http.HttpClient.DefaultHttpClient.LogicalHandler').setLevel(logging.CRITICAL)
-logging.getLogger('System.Net.Http.HttpClient.DefaultHttpClient.ClientHandler').setLevel(logging.CRITICAL)
-logging.getLogger('Tableau.Migration.Net.Logging.HttpActivityLogger').setLevel(logging.CRITICAL)
-logging.getLogger('Tableau.Migration.Engine.Conversion.Schedules.ServerToCloudScheduleConverter').setLevel(logging.CRITICAL)
-logging.getLogger('Tableau.Migration.Engine.Hooks.Transformers').setLevel(logging.CRITICAL)
-logging.getLogger('Polly').setLevel(logging.CRITICAL)
-logging.getLogger('System.Net.Http.HttpClient').setLevel(logging.CRITICAL)
-# Keep Tableau.Migration.Engine at INFO to see content creation messages
-logging.getLogger('Tableau.Migration.Engine').setLevel(logging.INFO)
-
-
-# =============================================================================
-# CONFIGURATION - Load from config.json
-# =============================================================================
-
-def load_config(config_path='config.json'):
-    """Load credentials from config.json file."""
-    config_file = Path(config_path)
-
-    if not config_file.exists():
-        print(f"❌ Config file not found: {config_path}")
-        print(f"\n📋 Setup instructions:")
-        print(f"   1. Copy the template: cp config.json.template config.json")
-        print(f"   2. Edit config.json with your actual credentials")
-        print(f"   3. Run this script again\n")
-        return None
-
-    with open(config_file, 'r') as f:
-        return json.load(f)
-
-def validate_config(config):
-    """Validate that config has all required fields."""
-    if not config:
-        return False
-
-    required_fields = {
-        'source': ['server_url', 'site_content_url', 'access_token_name', 'access_token'],
-        'destination': ['pod_url', 'site_content_url', 'access_token_name', 'access_token']
-    }
-
-    missing = []
-
-    # Check source and destination sections
-    for section, fields in required_fields.items():
-        if section not in config:
-            missing.append(f"Missing '{section}' section")
-            continue
-        for field in fields:
-            if field not in config[section] or not config[section][field]:
-                missing.append(f"{section}.{field}")
-
-    # Check for default content owner
-    if 'default_content_owner' not in config or not config['default_content_owner']:
-        missing.append("default_content_owner (email of user to own content when original owner doesn't exist)")
-
-    if missing:
-        print("❌ Missing or empty fields in config.json:")
-        for m in missing:
-            print(f"   - {m}")
-        return False
-
-    return True
-
-
-# =============================================================================
-# USERNAME MAPPING - Map to Cloud users with fallback to default owner
-# =============================================================================
-
-class ContentOwnerMapping(TableauCloudUsernameMappingBase):
-    """
-    Map Server usernames to Cloud users.
-    Falls back to default owner if user doesn't exist in Cloud.
-    """
-
-    def __init__(self, default_owner):
-        self.default_owner = default_owner
-        super().__init__()
-
-    def map(self, ctx):
-        username = ctx.content_item.name
-        _tableau_user_domain = ctx.mapped_location.parent()
-
-        # Try to map the user
-        if "@" in username:
-            # Already an email
-            mapped_email = username
-        else:
-            # Append @keyrus.com to create email
-            mapped_email = f"{username}@keyrus.com"
-
-        print(f"👤 Mapping content owner: {username} → {mapped_email}")
-
-        # NOTE: If this user doesn't exist in Cloud, the migration will reassign
-        # to the default owner specified in config. This happens automatically
-        # when the user lookup fails.
-
-        # Return the mapped context with proper location object
-        return ctx.map_to(_tableau_user_domain.append(mapped_email))
-
-
-# =============================================================================
-# FILTERS - ONLY migrate datasources and workbooks
-# =============================================================================
-
-class SkipUserMigration(ContentFilterBase[IUser]):
-    """Don't migrate users - they should already exist in Cloud."""
-
-    def should_migrate(self, item):
-        return False  # Skip all users
-
-
-class SkipGroupMigration(ContentFilterBase[IGroup]):
-    """Don't migrate groups - they should already exist in Cloud."""
-
-    def should_migrate(self, item):
-        return False  # Skip all groups
-
-
-class SkipProjectMigration(ContentFilterBase[IProject]):
-    """Don't migrate projects - they should already exist in Cloud."""
-
-    def should_migrate(self, item):
-        return False  # Skip all projects
-
-
-# Subscriptions are automatically skipped - not included in migration types
+configure_logging()
 
 
 # =============================================================================
@@ -157,30 +29,34 @@ class SkipProjectMigration(ContentFilterBase[IProject]):
 # =============================================================================
 
 def migrate_content():
-    """Migrate ONLY data sources and workbooks from Server to Cloud."""
+    """Migrate data sources and workbooks from Server to Cloud."""
 
     # Load and validate configuration
     config = load_config()
     if not config or not validate_config(config):
         return
 
-    # Get default content owner
+    # Get config values
     default_owner = config.get('default_content_owner', '')
     if not default_owner:
-        print("❌ Missing 'default_content_owner' in config.json")
+        print("Missing 'default_content_owner' in config.json")
         print("   This email will own content when the original owner doesn't exist in Cloud")
         return
 
-    print("✅ Configuration loaded successfully")
-    print(f"   Default content owner: {default_owner}\n")
+    email_domain = config['default_email_domain']
+    scope = get_migration_scope(config)
+
+    print("Configuration loaded successfully")
+    print(f"   Default content owner: {default_owner}")
+    print(f"   Email domain: {email_domain}\n")
     print("=" * 70)
     print("MIGRATION SCOPE:")
-    print("  ✅ Data Sources - WILL BE MIGRATED")
-    print("  ✅ Workbooks - WILL BE MIGRATED")
-    print("  ❌ Users - WILL NOT BE MIGRATED")
-    print("  ❌ Groups - WILL NOT BE MIGRATED")
-    print("  ❌ Projects - WILL NOT BE MIGRATED")
-    print("  ❌ Subscriptions - WILL NOT BE MIGRATED")
+    print(f"  {'YES' if scope['data_sources'] else 'NO ':>3} Data Sources - {'WILL BE MIGRATED' if scope['data_sources'] else 'WILL NOT BE MIGRATED'}")
+    print(f"  {'YES' if scope['workbooks'] else 'NO ':>3} Workbooks - {'WILL BE MIGRATED' if scope['workbooks'] else 'WILL NOT BE MIGRATED'}")
+    print("   NO Users - WILL NOT BE MIGRATED")
+    print("   NO Groups - WILL NOT BE MIGRATED")
+    print("   NO Projects - WILL NOT BE MIGRATED")
+    print("   NO Subscriptions - WILL NOT BE MIGRATED")
     print("=" * 70)
     print(f"\nSource: {config['source']['server_url']} / {config['source']['site_content_url'] if config['source']['site_content_url'] else 'Default'}")
     print(f"Destination: {config['destination']['pod_url']} / {config['destination']['site_content_url']}\n")
@@ -191,8 +67,8 @@ def migrate_content():
     # Build plan
     plan_builder = MigrationPlanBuilder()
 
-    # Create content owner mapping with default fallback
-    owner_mapping = ContentOwnerMapping(default_owner)
+    # Create username mapping with email domain from config
+    owner_mapping = EmailDomainMapping(email_domain, default_owner)
 
     plan_builder = (
         plan_builder
@@ -213,28 +89,32 @@ def migrate_content():
         .with_tableau_cloud_usernames(lambda ctx: owner_mapping.map(ctx))
     )
 
-    # Add filters to skip everything except datasources and workbooks
+    # Always skip users, groups, projects
     print("Configuring content filters...")
     plan_builder.filters.add(SkipUserMigration)
     plan_builder.filters.add(SkipGroupMigration)
     plan_builder.filters.add(SkipProjectMigration)
+
+    # Conditionally skip based on migration_scope config
+    if not scope['data_sources']:
+        plan_builder.filters.add(SkipDataSourceMigration)
+    if not scope['workbooks']:
+        plan_builder.filters.add(SkipWorkbookMigration)
 
     # Build and execute
     print("Building migration plan...")
     plan = plan_builder.build()
 
     print("\nStarting migration...\n")
-    print("📊 Migrating data sources...")
-    print("📈 Migrating workbooks...\n")
     result = migration.execute(plan)
 
     # Results
     print("\n" + "="*50)
     if result.status.name == "Completed":
-        print("✅ Migration completed!")
+        print("Migration completed!")
         print(f"   Check your Cloud site for migrated content")
     else:
-        print(f"❌ Migration failed: {result.status}")
+        print(f"Migration failed: {result.status}")
         if hasattr(result, 'errors') and result.errors:
             for error in result.errors:
                 print(f"   {error}")

--- a/content_migration.py
+++ b/content_migration.py
@@ -10,10 +10,6 @@ Usage:
 
 import argparse
 
-from tableau_migration import (
-    Migrator,
-    MigrationPlanBuilder,
-)
 from migration_utils import (
     configure_logging,
     load_config,
@@ -46,6 +42,9 @@ def migrate_content(dry_run=False):
     if dry_run:
         print_dry_run_report(config)
         return
+
+    # SDK imports deferred so --dry-run works without tableau_migration installed
+    from tableau_migration import Migrator, MigrationPlanBuilder
 
     # Get config values
     default_owner = config.get('default_content_owner', '')

--- a/dry_run.py
+++ b/dry_run.py
@@ -1,0 +1,84 @@
+"""
+Dry Run - Validate configuration and preview migration without executing.
+
+Usage:
+    python dry_run.py                  # Validate config only (no SDK needed)
+    python dry_run.py --connect        # Also verify server connectivity via SDK
+"""
+
+import argparse
+
+from migration_utils import (
+    configure_logging,
+    load_config,
+    validate_config,
+    print_dry_run_report,
+)
+
+configure_logging()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate migration config and preview what would happen."
+    )
+    parser.add_argument(
+        "--connect",
+        action="store_true",
+        help="Also build the SDK plan to verify server connectivity (requires tableau_migration).",
+    )
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to config file (default: config.json).",
+    )
+    args = parser.parse_args()
+
+    # Load and validate config
+    config = load_config(args.config)
+    if not config:
+        return
+
+    print("Validating configuration...")
+    if not validate_config(config):
+        return
+    print("Configuration is valid.")
+
+    # Print the dry-run report
+    print_dry_run_report(config)
+
+    # Optionally verify connectivity by building the SDK plan
+    if args.connect:
+        print("Verifying server connectivity...")
+        try:
+            from tableau_migration import MigrationPlanBuilder
+
+            plan_builder = MigrationPlanBuilder()
+            plan_builder = (
+                plan_builder
+                .from_source_tableau_server(
+                    server_url=config['source']['server_url'],
+                    site_content_url=config['source']['site_content_url'],
+                    access_token_name=config['source']['access_token_name'],
+                    access_token=config['source']['access_token'],
+                )
+                .to_destination_tableau_cloud(
+                    pod_url=config['destination']['pod_url'],
+                    site_content_url=config['destination']['site_content_url'],
+                    access_token_name=config['destination']['access_token_name'],
+                    access_token=config['destination']['access_token'],
+                )
+                .for_server_to_cloud()
+                .with_tableau_id_authentication_type()
+            )
+
+            plan = plan_builder.build()
+            print("Plan built successfully — credentials and endpoints are valid.\n")
+        except ImportError:
+            print("tableau_migration package not installed. Skipping connectivity check.\n")
+        except Exception as e:
+            print(f"Connectivity check failed: {e}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/migration_utils.py
+++ b/migration_utils.py
@@ -1,0 +1,216 @@
+"""
+Shared Utilities for Tableau Migration Scripts
+Common logging, configuration, filters, and mapping logic
+used by both content_migration.py and subscription migration.
+"""
+
+import logging
+import json
+from pathlib import Path
+
+try:
+    from tableau_migration import (
+        TableauCloudUsernameMappingBase,
+        ContentFilterBase,
+        IUser,
+        IGroup,
+        IProject,
+        IDataSource,
+        IWorkbook
+    )
+except ImportError:
+    # SDK not available (e.g., testing without .NET runtime).
+    # Provide stub base classes so pure-Python utilities remain importable.
+    class TableauCloudUsernameMappingBase:
+        pass
+
+    class _ContentFilterBaseMeta(type):
+        def __getitem__(cls, item):
+            return cls
+
+    class ContentFilterBase(metaclass=_ContentFilterBaseMeta):
+        pass
+
+    IUser = IGroup = IProject = IDataSource = IWorkbook = None
+
+
+# =============================================================================
+# LOGGING SETUP
+# =============================================================================
+
+def configure_logging():
+    """Configure logging - show migration progress but suppress verbose HTTP/retry logs."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(message)s'
+    )
+
+    # Silence the noisy loggers (HTTP requests, retries, etc.)
+    noisy_loggers = [
+        'System.Net.Http.HttpClient.DefaultHttpClient.LogicalHandler',
+        'System.Net.Http.HttpClient.DefaultHttpClient.ClientHandler',
+        'Tableau.Migration.Net.Logging.HttpActivityLogger',
+        'Tableau.Migration.Engine.Conversion.Schedules.ServerToCloudScheduleConverter',
+        'Tableau.Migration.Engine.Hooks.Transformers',
+        'Polly',
+        'System.Net.Http.HttpClient',
+    ]
+    for logger_name in noisy_loggers:
+        logging.getLogger(logger_name).setLevel(logging.CRITICAL)
+
+    # Keep migration engine at INFO to see content creation messages
+    logging.getLogger('Tableau.Migration.Engine').setLevel(logging.INFO)
+
+
+# =============================================================================
+# CONFIGURATION - Load and validate config.json
+# =============================================================================
+
+# Default migration scope when not specified in config
+DEFAULT_MIGRATION_SCOPE = {
+    'data_sources': True,
+    'workbooks': True,
+}
+
+
+def load_config(config_path='config.json'):
+    """Load credentials from config.json file."""
+    config_file = Path(config_path)
+
+    if not config_file.exists():
+        print(f"Config file not found: {config_path}")
+        print(f"\nSetup instructions:")
+        print(f"   1. Copy the template: cp config.json.template config.json")
+        print(f"   2. Edit config.json with your actual credentials")
+        print(f"   3. Run this script again\n")
+        return None
+
+    with open(config_file, 'r') as f:
+        return json.load(f)
+
+
+def validate_config(config):
+    """Validate that config has all required fields."""
+    if not config:
+        return False
+
+    required_fields = {
+        'source': ['server_url', 'site_content_url', 'access_token_name', 'access_token'],
+        'destination': ['pod_url', 'site_content_url', 'access_token_name', 'access_token']
+    }
+
+    # Fields where empty string is a valid value (e.g., default site)
+    allow_empty = {'site_content_url'}
+
+    missing = []
+
+    for section, fields in required_fields.items():
+        if section not in config:
+            missing.append(f"Missing '{section}' section")
+            continue
+        for field in fields:
+            if field not in config[section]:
+                missing.append(f"{section}.{field}")
+            elif not config[section][field] and field not in allow_empty:
+                missing.append(f"{section}.{field}")
+
+    if 'default_content_owner' not in config or not config['default_content_owner']:
+        missing.append("default_content_owner (email of user to own content when original owner doesn't exist)")
+
+    if 'default_email_domain' not in config or not config['default_email_domain']:
+        missing.append("default_email_domain (e.g., '@yourcompany.com' - appended to usernames without '@')")
+
+    if missing:
+        print("Missing or empty fields in config.json:")
+        for m in missing:
+            print(f"   - {m}")
+        return False
+
+    return True
+
+
+def get_migration_scope(config):
+    """
+    Parse migration_scope from config with sensible defaults.
+
+    Returns a dict like {'data_sources': True, 'workbooks': True}.
+    If migration_scope is missing from config, all content types
+    default to True (migrate everything).
+    """
+    scope = config.get('migration_scope', {})
+    return {key: scope.get(key, default) for key, default in DEFAULT_MIGRATION_SCOPE.items()}
+
+
+# =============================================================================
+# FILTERS - Skip content types that should not be migrated
+# =============================================================================
+
+class SkipUserMigration(ContentFilterBase[IUser]):
+    """Don't migrate users - they should already exist in Cloud."""
+
+    def should_migrate(self, item):
+        return False
+
+
+class SkipGroupMigration(ContentFilterBase[IGroup]):
+    """Don't migrate groups - they should already exist in Cloud."""
+
+    def should_migrate(self, item):
+        return False
+
+
+class SkipProjectMigration(ContentFilterBase[IProject]):
+    """Don't migrate projects - they should already exist in Cloud."""
+
+    def should_migrate(self, item):
+        return False
+
+
+class SkipDataSourceMigration(ContentFilterBase[IDataSource]):
+    """Don't migrate data sources - they should already exist in Cloud."""
+
+    def should_migrate(self, item):
+        return False
+
+
+class SkipWorkbookMigration(ContentFilterBase[IWorkbook]):
+    """Don't migrate workbooks - they should already exist in Cloud."""
+
+    def should_migrate(self, item):
+        return False
+
+
+# =============================================================================
+# USERNAME MAPPING - Map Server usernames to Cloud emails
+# =============================================================================
+
+class EmailDomainMapping(TableauCloudUsernameMappingBase):
+    """
+    Map Server usernames to Cloud email addresses.
+
+    If the username already contains '@', it is used as-is.
+    Otherwise, the configured email domain is appended.
+
+    Args:
+        email_domain: Domain to append (e.g., '@yourcompany.com').
+        default_owner: Optional fallback email for content ownership.
+    """
+
+    def __init__(self, email_domain, default_owner=None):
+        self.email_domain = email_domain
+        self.default_owner = default_owner
+        super().__init__()
+
+    def map(self, ctx):
+        username = ctx.content_item.name
+        _tableau_user_domain = ctx.mapped_location.parent()
+
+        if "@" in username:
+            mapped_email = username
+        else:
+            # Ensure domain starts with '@'
+            domain = self.email_domain if self.email_domain.startswith('@') else f"@{self.email_domain}"
+            mapped_email = f"{username}{domain}"
+
+        print(f"Mapping: {username} -> {mapped_email}")
+        return ctx.map_to(_tableau_user_domain.append(mapped_email))

--- a/migration_utils.py
+++ b/migration_utils.py
@@ -181,6 +181,101 @@ class SkipWorkbookMigration(ContentFilterBase[IWorkbook]):
 
 
 # =============================================================================
+# DRY-RUN REPORT - Preview migration without executing
+# =============================================================================
+
+# Sample usernames used to preview email mapping behavior
+SAMPLE_USERNAMES = ["jsmith", "alice.jones", "bob@existing.com", "admin"]
+
+
+def print_dry_run_report(config):
+    """
+    Print a pre-migration validation report.
+
+    Shows configuration, migration scope, email mapping preview,
+    and connectivity info — everything that would happen during
+    migration, without actually migrating anything.
+    """
+    scope = get_migration_scope(config)
+    email_domain = config.get('default_email_domain', '')
+    default_owner = config.get('default_content_owner', '')
+
+    print()
+    print("=" * 60)
+    print("  DRY-RUN REPORT")
+    print("=" * 60)
+
+    # 1. Connection info
+    print("\n1. CONNECTION INFO")
+    print("-" * 40)
+    src = config.get('source', {})
+    dst = config.get('destination', {})
+    print(f"   Source:      {src.get('server_url', '?')}")
+    print(f"   Source site: {src.get('site_content_url') or 'Default'}")
+    print(f"   Dest:        {dst.get('pod_url', '?')}")
+    print(f"   Dest site:   {dst.get('site_content_url', '?')}")
+    print(f"   Token (src): {src.get('access_token_name', '?')}")
+    print(f"   Token (dst): {dst.get('access_token_name', '?')}")
+
+    # 2. Ownership
+    print(f"\n2. CONTENT OWNERSHIP")
+    print("-" * 40)
+    print(f"   Default owner: {default_owner}")
+    print(f"   Email domain:  {email_domain}")
+
+    # 3. Migration scope
+    print(f"\n3. MIGRATION SCOPE")
+    print("-" * 40)
+    for content_type, will_migrate in scope.items():
+        label = content_type.replace('_', ' ').title()
+        status = "WILL MIGRATE" if will_migrate else "SKIP"
+        marker = ">>>" if will_migrate else "   "
+        print(f"   {marker} {label}: {status}")
+    print(f"       Users: SKIP (always)")
+    print(f"       Groups: SKIP (always)")
+    print(f"       Projects: SKIP (always)")
+
+    # 4. Email mapping preview
+    print(f"\n4. EMAIL MAPPING PREVIEW")
+    print("-" * 40)
+    for username in SAMPLE_USERNAMES:
+        mapped = preview_email_mapping(username, email_domain)
+        print(f"   {username:<30} -> {mapped}")
+
+    # 5. What would happen
+    items_to_migrate = [k for k, v in scope.items() if v]
+    items_to_skip = [k for k, v in scope.items() if not v]
+
+    print(f"\n5. SUMMARY")
+    print("-" * 40)
+    if items_to_migrate:
+        print(f"   Will migrate: {', '.join(t.replace('_', ' ') for t in items_to_migrate)}")
+    else:
+        print(f"   Will migrate: (nothing)")
+    skipped = [t.replace('_', ' ') for t in items_to_skip]
+    skipped.extend(["users", "groups", "projects"])
+    print(f"   Will skip:    {', '.join(skipped)}")
+
+    print()
+    print("=" * 60)
+    print("  DRY RUN COMPLETE - no changes were made")
+    print("=" * 60)
+    print()
+
+
+def preview_email_mapping(username, email_domain):
+    """
+    Preview how a username would be mapped to a Cloud email.
+
+    Same logic as EmailDomainMapping.map() but without SDK context objects.
+    """
+    if "@" in username:
+        return username
+    domain = email_domain if email_domain.startswith('@') else f"@{email_domain}"
+    return f"{username}{domain}"
+
+
+# =============================================================================
 # USERNAME MAPPING - Map Server usernames to Cloud emails
 # =============================================================================
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*

--- a/subscriptions/simple_subscription_migration.py
+++ b/subscriptions/simple_subscription_migration.py
@@ -1,8 +1,13 @@
 """
 Simple Subscription Migration - Single File
 ONLY migrates subscriptions - skips users and workbooks (assumes they exist in Cloud).
+
+Usage:
+    python simple_subscription_migration.py              # Run the migration
+    python simple_subscription_migration.py --dry-run    # Preview without migrating
 """
 
+import argparse
 import sys
 import os
 
@@ -17,6 +22,7 @@ from migration_utils import (
     configure_logging,
     load_config,
     validate_config,
+    print_dry_run_report,
     EmailDomainMapping,
     SkipUserMigration,
     SkipProjectMigration,
@@ -31,7 +37,7 @@ configure_logging()
 # MIGRATION
 # =============================================================================
 
-def migrate_subscriptions():
+def migrate_subscriptions(dry_run=False):
     """Migrate subscriptions from Server to Cloud."""
 
     # Load config from repo root
@@ -41,6 +47,10 @@ def migrate_subscriptions():
     )
     config = load_config(config_path)
     if not config or not validate_config(config):
+        return
+
+    if dry_run:
+        print_dry_run_report(config)
         return
 
     email_domain = config['default_email_domain']
@@ -106,4 +116,7 @@ def migrate_subscriptions():
 
 
 if __name__ == "__main__":
-    migrate_subscriptions()
+    parser = argparse.ArgumentParser(description="Migrate subscriptions from Tableau Server to Cloud.")
+    parser.add_argument("--dry-run", action="store_true", help="Preview migration without executing.")
+    args = parser.parse_args()
+    migrate_subscriptions(dry_run=args.dry_run)

--- a/subscriptions/simple_subscription_migration.py
+++ b/subscriptions/simple_subscription_migration.py
@@ -3,110 +3,28 @@ Simple Subscription Migration - Single File
 ONLY migrates subscriptions - skips users and workbooks (assumes they exist in Cloud).
 """
 
-import logging
+import sys
+import os
+
+# Add parent directory to path so we can import migration_utils from repo root
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from tableau_migration import (
     Migrator,
     MigrationPlanBuilder,
-    TableauCloudUsernameMappingBase,
-    ContentFilterBase,
-    IUser,
-    IWorkbook,
-    IDataSource,
-    IProject
+)
+from migration_utils import (
+    configure_logging,
+    load_config,
+    validate_config,
+    EmailDomainMapping,
+    SkipUserMigration,
+    SkipProjectMigration,
+    SkipDataSourceMigration,
+    SkipWorkbookMigration,
 )
 
-# Configure logging - show subscription progress but suppress verbose HTTP/retry logs
-logging.basicConfig(
-    level=logging.INFO,  # Allow INFO messages through
-    format='%(message)s'
-)
-
-# Silence the noisy loggers (HTTP requests, retries, etc.) but keep migration engine visible
-logging.getLogger('System.Net.Http.HttpClient.DefaultHttpClient.LogicalHandler').setLevel(logging.CRITICAL)
-logging.getLogger('System.Net.Http.HttpClient.DefaultHttpClient.ClientHandler').setLevel(logging.CRITICAL)
-logging.getLogger('Tableau.Migration.Net.Logging.HttpActivityLogger').setLevel(logging.CRITICAL)
-logging.getLogger('Tableau.Migration.Engine.Conversion.Schedules.ServerToCloudScheduleConverter').setLevel(logging.CRITICAL)
-logging.getLogger('Tableau.Migration.Engine.Hooks.Transformers').setLevel(logging.CRITICAL)
-logging.getLogger('Polly').setLevel(logging.CRITICAL)
-logging.getLogger('System.Net.Http.HttpClient').setLevel(logging.CRITICAL)
-# Keep Tableau.Migration.Engine at INFO to see subscription creation messages
-logging.getLogger('Tableau.Migration.Engine').setLevel(logging.INFO)
-
-
-# =============================================================================
-# CONFIGURATION - EDIT THESE
-# =============================================================================
-
-# SOURCE: Tableau Server
-SOURCE_SERVER_URL = "https://your-tableau-server.com"
-SOURCE_SITE = ""  # Empty string for default site, or "site-name"
-SOURCE_TOKEN_NAME = "your-token-name"
-SOURCE_TOKEN = "your-token-secret"
-
-# DESTINATION: Tableau Cloud
-DEST_CLOUD_URL = "https://10ax.online.tableau.com"  # Change pod: 10ax, 10ay, etc.
-DEST_SITE = "your-cloud-site"
-DEST_TOKEN_NAME = "your-cloud-token-name"
-DEST_TOKEN = "your-cloud-token-secret"
-
-
-# =============================================================================
-# USERNAME MAPPING - Just append @keyrus.com to find matching Cloud users
-# =============================================================================
-
-class SimpleUsernameMapping(TableauCloudUsernameMappingBase):
-    """Append @keyrus.com to Server usernames to match Cloud users."""
-
-    def map(self, ctx):
-        username = ctx.content_item.name
-        _tableau_user_domain = ctx.mapped_location.parent()
-
-        # Already an email? Return as-is
-        if "@" in username:
-            return ctx.map_to(_tableau_user_domain.append(username))
-
-        # Append @keyrus.com
-        email = f"{username}@keyrus.com"
-        print(f"👤 Mapping: {username} → {email}")
-
-        # Return the mapped context with proper location object
-        return ctx.map_to(_tableau_user_domain.append(email))
-
-
-# =============================================================================
-# FILTERS - Control what content actually gets migrated
-# =============================================================================
-
-class SkipUserMigration(ContentFilterBase[IUser]):
-    """Don't migrate users - they should already exist in Cloud."""
-
-    def should_migrate(self, item):
-        print(f"⏭️  Skipping user: {item.source_item.name}")
-        return False  # Don't migrate users
-
-
-class SkipProjectMigration(ContentFilterBase[IProject]):
-    """Don't migrate projects - they should already exist in Cloud."""
-
-    def should_migrate(self, item):
-        print(f"⏭️  Skipping project: {item.source_item.name}")
-        return False  # Don't migrate projects
-
-
-class SkipDataSourceMigration(ContentFilterBase[IDataSource]):
-    """Don't migrate data sources - they should already exist in Cloud."""
-
-    def should_migrate(self, item):
-        print(f"⏭️  Skipping data source: {item.source_item.name}")
-        return False  # Don't migrate data sources
-
-
-class SkipWorkbookMigration(ContentFilterBase[IWorkbook]):
-    """Don't migrate workbooks - they should already exist in Cloud."""
-
-    def should_migrate(self, item):
-        print(f"⏭️  Skipping workbook: {item.source_item.name}")
-        return False  # Don't migrate workbooks
+configure_logging()
 
 
 # =============================================================================
@@ -116,9 +34,20 @@ class SkipWorkbookMigration(ContentFilterBase[IWorkbook]):
 def migrate_subscriptions():
     """Migrate subscriptions from Server to Cloud."""
 
+    # Load config from repo root
+    config_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        'config.json'
+    )
+    config = load_config(config_path)
+    if not config or not validate_config(config):
+        return
+
+    email_domain = config['default_email_domain']
+
     print("Starting subscription migration...")
-    print(f"Source: {SOURCE_SERVER_URL} / {SOURCE_SITE if SOURCE_SITE else 'Default'}")
-    print(f"Destination: {DEST_CLOUD_URL} / {DEST_SITE}\n")
+    print(f"Source: {config['source']['server_url']} / {config['source']['site_content_url'] if config['source']['site_content_url'] else 'Default'}")
+    print(f"Destination: {config['destination']['pod_url']} / {config['destination']['site_content_url']}\n")
 
     # Create migrator
     migration = Migrator()
@@ -126,23 +55,26 @@ def migrate_subscriptions():
     # Build plan
     plan_builder = MigrationPlanBuilder()
 
+    # Create username mapping once (not per-call)
+    username_mapping = EmailDomainMapping(email_domain)
+
     plan_builder = (
         plan_builder
         .from_source_tableau_server(
-            server_url=SOURCE_SERVER_URL,
-            site_content_url=SOURCE_SITE,
-            access_token_name=SOURCE_TOKEN_NAME,
-            access_token=SOURCE_TOKEN
+            server_url=config['source']['server_url'],
+            site_content_url=config['source']['site_content_url'],
+            access_token_name=config['source']['access_token_name'],
+            access_token=config['source']['access_token']
         )
         .to_destination_tableau_cloud(
-            pod_url=DEST_CLOUD_URL,
-            site_content_url=DEST_SITE,
-            access_token_name=DEST_TOKEN_NAME,
-            access_token=DEST_TOKEN
+            pod_url=config['destination']['pod_url'],
+            site_content_url=config['destination']['site_content_url'],
+            access_token_name=config['destination']['access_token_name'],
+            access_token=config['destination']['access_token']
         )
         .for_server_to_cloud()
         .with_tableau_id_authentication_type()
-        .with_tableau_cloud_usernames(lambda ctx: SimpleUsernameMapping().map(ctx))
+        .with_tableau_cloud_usernames(lambda ctx: username_mapping.map(ctx))
     )
 
     # Add filters to skip migrating users, projects, data sources, and workbooks
@@ -163,10 +95,10 @@ def migrate_subscriptions():
     # Results
     print("\n" + "="*50)
     if result.status.name == "Completed":
-        print("✅ Migration completed!")
+        print("Migration completed!")
         print(f"   Check your Cloud site for migrated content")
     else:
-        print(f"❌ Migration failed: {result.status}")
+        print(f"Migration failed: {result.status}")
         if hasattr(result, 'errors') and result.errors:
             for error in result.errors:
                 print(f"   {error}")

--- a/subscriptions/simple_subscription_migration.py
+++ b/subscriptions/simple_subscription_migration.py
@@ -14,10 +14,6 @@ import os
 # Add parent directory to path so we can import migration_utils from repo root
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from tableau_migration import (
-    Migrator,
-    MigrationPlanBuilder,
-)
 from migration_utils import (
     configure_logging,
     load_config,
@@ -52,6 +48,9 @@ def migrate_subscriptions(dry_run=False):
     if dry_run:
         print_dry_run_report(config)
         return
+
+    # SDK imports deferred so --dry-run works without tableau_migration installed
+    from tableau_migration import Migrator, MigrationPlanBuilder
 
     email_domain = config['default_email_domain']
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,89 @@
+"""Shared test fixtures for migration tests."""
+
+import json
+import os
+import sys
+
+import pytest
+from unittest.mock import MagicMock
+
+# Ensure migration_utils is importable from repo root
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@pytest.fixture
+def valid_config():
+    """Return a complete, valid configuration dict."""
+    return {
+        "source": {
+            "server_url": "https://test-server.com",
+            "site_content_url": "test-site",
+            "access_token_name": "test-token-name",
+            "access_token": "test-token-secret"
+        },
+        "destination": {
+            "pod_url": "https://10ax.online.tableau.com",
+            "site_content_url": "cloud-site",
+            "access_token_name": "cloud-token-name",
+            "access_token": "cloud-token-secret"
+        },
+        "default_content_owner": "admin@test.com",
+        "default_email_domain": "@test.com",
+        "migration_scope": {
+            "data_sources": True,
+            "workbooks": True
+        }
+    }
+
+
+@pytest.fixture
+def config_without_scope():
+    """Config without migration_scope (backward compatibility test)."""
+    return {
+        "source": {
+            "server_url": "https://test-server.com",
+            "site_content_url": "test-site",
+            "access_token_name": "test-token-name",
+            "access_token": "test-token-secret"
+        },
+        "destination": {
+            "pod_url": "https://10ax.online.tableau.com",
+            "site_content_url": "cloud-site",
+            "access_token_name": "cloud-token-name",
+            "access_token": "cloud-token-secret"
+        },
+        "default_content_owner": "admin@test.com",
+        "default_email_domain": "@test.com"
+    }
+
+
+@pytest.fixture
+def tmp_config_file(tmp_path, valid_config):
+    """Write a valid config to a temp file and return its path."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(valid_config))
+    return str(config_path)
+
+
+@pytest.fixture
+def mock_mapping_context():
+    """
+    Factory fixture that creates a mock mapping context for a given username.
+
+    The SDK context has:
+      - ctx.content_item.name  (the username string)
+      - ctx.mapped_location.parent()  (returns a domain object)
+      - ctx.map_to(location)  (returns mapped context)
+    """
+    def _make_context(username):
+        ctx = MagicMock()
+        ctx.content_item.name = username
+
+        domain = MagicMock()
+        ctx.mapped_location.parent.return_value = domain
+
+        # map_to returns the context itself (for chaining)
+        ctx.map_to.return_value = ctx
+        return ctx
+
+    return _make_context

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,85 @@
+"""Tests for configuration loading and validation."""
+
+import json
+
+import pytest
+
+from migration_utils import load_config, validate_config
+
+
+class TestLoadConfig:
+    """Tests for load_config function."""
+
+    def test_load_valid_config(self, tmp_config_file, valid_config):
+        """Loading a valid config.json returns a dict with expected keys."""
+        config = load_config(config_path=tmp_config_file)
+        assert config is not None
+        assert config == valid_config
+
+    def test_load_missing_config(self, tmp_path):
+        """Loading a nonexistent file returns None."""
+        config = load_config(config_path=str(tmp_path / "nonexistent.json"))
+        assert config is None
+
+    def test_load_invalid_json(self, tmp_path):
+        """Loading a file with invalid JSON raises an error."""
+        bad_file = tmp_path / "config.json"
+        bad_file.write_text("not valid json {{{")
+        with pytest.raises(json.JSONDecodeError):
+            load_config(config_path=str(bad_file))
+
+
+class TestValidateConfig:
+    """Tests for validate_config function."""
+
+    def test_valid_config_passes(self, valid_config):
+        """A complete config passes validation."""
+        assert validate_config(valid_config) is True
+
+    def test_none_config_fails(self):
+        """None config fails validation."""
+        assert validate_config(None) is False
+
+    def test_empty_config_fails(self):
+        """Empty dict fails validation."""
+        assert validate_config({}) is False
+
+    def test_missing_source_section_fails(self, valid_config):
+        """Missing 'source' section fails."""
+        del valid_config['source']
+        assert validate_config(valid_config) is False
+
+    def test_missing_destination_section_fails(self, valid_config):
+        """Missing 'destination' section fails."""
+        del valid_config['destination']
+        assert validate_config(valid_config) is False
+
+    def test_missing_default_content_owner_fails(self, valid_config):
+        """Missing default_content_owner fails."""
+        del valid_config['default_content_owner']
+        assert validate_config(valid_config) is False
+
+    def test_missing_default_email_domain_fails(self, valid_config):
+        """Missing default_email_domain fails."""
+        del valid_config['default_email_domain']
+        assert validate_config(valid_config) is False
+
+    def test_empty_access_token_fails(self, valid_config):
+        """Empty access_token in source fails."""
+        valid_config['source']['access_token'] = ''
+        assert validate_config(valid_config) is False
+
+    def test_missing_single_source_field_fails(self, valid_config):
+        """Missing a single required source field fails."""
+        del valid_config['source']['server_url']
+        assert validate_config(valid_config) is False
+
+    def test_empty_site_content_url_is_valid(self, valid_config):
+        """Empty string for site_content_url is valid (means default site)."""
+        valid_config['source']['site_content_url'] = ''
+        assert validate_config(valid_config) is True
+
+    def test_missing_site_content_url_fails(self, valid_config):
+        """Missing site_content_url key entirely still fails."""
+        del valid_config['source']['site_content_url']
+        assert validate_config(valid_config) is False

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,99 @@
+"""Tests for dry-run report and email mapping preview."""
+
+import pytest
+
+from migration_utils import (
+    preview_email_mapping,
+    print_dry_run_report,
+    SAMPLE_USERNAMES,
+)
+
+
+class TestPreviewEmailMapping:
+    """Tests for the preview_email_mapping helper."""
+
+    def test_plain_username_gets_domain(self):
+        assert preview_email_mapping("jsmith", "@test.com") == "jsmith@test.com"
+
+    def test_email_passes_through(self):
+        assert preview_email_mapping("bob@existing.com", "@test.com") == "bob@existing.com"
+
+    def test_domain_without_at_sign(self):
+        assert preview_email_mapping("alice", "example.com") == "alice@example.com"
+
+    def test_domain_with_at_sign(self):
+        assert preview_email_mapping("alice", "@example.com") == "alice@example.com"
+
+    def test_empty_username(self):
+        assert preview_email_mapping("", "@test.com") == "@test.com"
+
+
+class TestSampleUsernames:
+    """Verify sample usernames cover key edge cases."""
+
+    def test_samples_include_plain_username(self):
+        assert any("@" not in u for u in SAMPLE_USERNAMES)
+
+    def test_samples_include_email(self):
+        assert any("@" in u for u in SAMPLE_USERNAMES)
+
+
+class TestPrintDryRunReport:
+    """Tests for print_dry_run_report output."""
+
+    def test_report_prints_without_error(self, valid_config, capsys):
+        print_dry_run_report(valid_config)
+        output = capsys.readouterr().out
+        assert "DRY-RUN REPORT" in output
+        assert "DRY RUN COMPLETE" in output
+
+    def test_report_shows_source_url(self, valid_config, capsys):
+        print_dry_run_report(valid_config)
+        output = capsys.readouterr().out
+        assert valid_config['source']['server_url'] in output
+
+    def test_report_shows_destination_url(self, valid_config, capsys):
+        print_dry_run_report(valid_config)
+        output = capsys.readouterr().out
+        assert valid_config['destination']['pod_url'] in output
+
+    def test_report_shows_default_owner(self, valid_config, capsys):
+        print_dry_run_report(valid_config)
+        output = capsys.readouterr().out
+        assert valid_config['default_content_owner'] in output
+
+    def test_report_shows_migration_scope(self, valid_config, capsys):
+        print_dry_run_report(valid_config)
+        output = capsys.readouterr().out
+        assert "WILL MIGRATE" in output
+
+    def test_report_shows_skipped_types(self, valid_config, capsys):
+        valid_config['migration_scope'] = {'data_sources': False, 'workbooks': False}
+        print_dry_run_report(valid_config)
+        output = capsys.readouterr().out
+        assert "SKIP" in output
+
+    def test_report_shows_mapping_preview(self, valid_config, capsys):
+        print_dry_run_report(valid_config)
+        output = capsys.readouterr().out
+        # Should show sample username mapped with configured domain
+        assert "jsmith@test.com" in output
+
+    def test_report_shows_email_passthrough(self, valid_config, capsys):
+        print_dry_run_report(valid_config)
+        output = capsys.readouterr().out
+        # bob@existing.com should pass through unchanged
+        assert "bob@existing.com" in output
+
+    def test_report_always_skips_users_groups_projects(self, valid_config, capsys):
+        print_dry_run_report(valid_config)
+        output = capsys.readouterr().out
+        assert "Users: SKIP (always)" in output
+        assert "Groups: SKIP (always)" in output
+        assert "Projects: SKIP (always)" in output
+
+    def test_report_with_default_site(self, valid_config, capsys):
+        valid_config['source']['site_content_url'] = ''
+        print_dry_run_report(valid_config)
+        output = capsys.readouterr().out
+        assert "Default" in output

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,29 @@
+"""Tests for content filter classes."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from migration_utils import (
+    SkipUserMigration,
+    SkipGroupMigration,
+    SkipProjectMigration,
+    SkipDataSourceMigration,
+    SkipWorkbookMigration,
+)
+
+
+class TestAlwaysSkipFilters:
+    """All skip filters should always return False."""
+
+    @pytest.mark.parametrize("filter_class", [
+        SkipUserMigration,
+        SkipGroupMigration,
+        SkipProjectMigration,
+        SkipDataSourceMigration,
+        SkipWorkbookMigration,
+    ])
+    def test_should_migrate_returns_false(self, filter_class):
+        """Every skip filter returns False for any item."""
+        filter_instance = filter_class()
+        mock_item = MagicMock()
+        assert filter_instance.should_migrate(mock_item) is False

--- a/tests/test_migration_scope.py
+++ b/tests/test_migration_scope.py
@@ -1,0 +1,48 @@
+"""Tests for migration_scope configuration parsing."""
+
+import pytest
+
+from migration_utils import get_migration_scope, DEFAULT_MIGRATION_SCOPE
+
+
+class TestGetMigrationScope:
+    """Tests for the get_migration_scope function."""
+
+    def test_full_scope_config(self, valid_config):
+        """Returns exact values from config when all keys present."""
+        scope = get_migration_scope(valid_config)
+        assert scope['data_sources'] is True
+        assert scope['workbooks'] is True
+
+    def test_scope_with_exclusions(self, valid_config):
+        """Respects False values in config."""
+        valid_config['migration_scope']['data_sources'] = False
+        scope = get_migration_scope(valid_config)
+        assert scope['data_sources'] is False
+        assert scope['workbooks'] is True
+
+    def test_missing_scope_defaults_to_all_true(self, config_without_scope):
+        """Missing migration_scope section defaults to all True."""
+        scope = get_migration_scope(config_without_scope)
+        assert scope['data_sources'] is True
+        assert scope['workbooks'] is True
+
+    def test_partial_scope_fills_defaults(self, valid_config):
+        """If only one key is provided, the other defaults to True."""
+        valid_config['migration_scope'] = {'data_sources': False}
+        scope = get_migration_scope(valid_config)
+        assert scope['data_sources'] is False
+        assert scope['workbooks'] is True
+
+    def test_empty_scope_object_defaults_to_all_true(self, valid_config):
+        """Empty migration_scope object defaults to all True."""
+        valid_config['migration_scope'] = {}
+        scope = get_migration_scope(valid_config)
+        assert scope == DEFAULT_MIGRATION_SCOPE
+
+    def test_all_false(self, valid_config):
+        """User can disable everything."""
+        valid_config['migration_scope'] = {'data_sources': False, 'workbooks': False}
+        scope = get_migration_scope(valid_config)
+        assert scope['data_sources'] is False
+        assert scope['workbooks'] is False

--- a/tests/test_username_mapping.py
+++ b/tests/test_username_mapping.py
@@ -1,0 +1,73 @@
+"""Tests for username/email mapping logic."""
+
+import pytest
+
+from migration_utils import EmailDomainMapping
+
+
+class TestEmailDomainMapping:
+    """Tests for the EmailDomainMapping class."""
+
+    def test_username_gets_domain_appended(self, mock_mapping_context):
+        """A plain username gets the email domain appended."""
+        mapping = EmailDomainMapping(email_domain="@test.com")
+        ctx = mock_mapping_context("jsmith")
+
+        mapping.map(ctx)
+
+        domain = ctx.mapped_location.parent.return_value
+        domain.append.assert_called_once_with("jsmith@test.com")
+        ctx.map_to.assert_called_once()
+
+    def test_email_username_passes_through(self, mock_mapping_context):
+        """A username that already contains '@' is used as-is."""
+        mapping = EmailDomainMapping(email_domain="@test.com")
+        ctx = mock_mapping_context("jsmith@existing.com")
+
+        mapping.map(ctx)
+
+        domain = ctx.mapped_location.parent.return_value
+        domain.append.assert_called_once_with("jsmith@existing.com")
+
+    def test_different_domain(self, mock_mapping_context):
+        """Different email domains are correctly appended."""
+        mapping = EmailDomainMapping(email_domain="@bigcorp.org")
+        ctx = mock_mapping_context("alice")
+
+        mapping.map(ctx)
+
+        domain = ctx.mapped_location.parent.return_value
+        domain.append.assert_called_once_with("alice@bigcorp.org")
+
+    def test_domain_without_at_sign(self, mock_mapping_context):
+        """If email_domain lacks leading '@', one is prepended."""
+        mapping = EmailDomainMapping(email_domain="example.com")
+        ctx = mock_mapping_context("bob")
+
+        mapping.map(ctx)
+
+        domain = ctx.mapped_location.parent.return_value
+        domain.append.assert_called_once_with("bob@example.com")
+
+    def test_domain_with_at_sign(self, mock_mapping_context):
+        """If email_domain already has '@', it is not doubled."""
+        mapping = EmailDomainMapping(email_domain="@example.com")
+        ctx = mock_mapping_context("bob")
+
+        mapping.map(ctx)
+
+        domain = ctx.mapped_location.parent.return_value
+        domain.append.assert_called_once_with("bob@example.com")
+
+    def test_default_owner_stored(self):
+        """The default_owner parameter is stored on the instance."""
+        mapping = EmailDomainMapping(
+            email_domain="@test.com",
+            default_owner="fallback@test.com"
+        )
+        assert mapping.default_owner == "fallback@test.com"
+
+    def test_default_owner_is_optional(self):
+        """The default_owner parameter defaults to None."""
+        mapping = EmailDomainMapping(email_domain="@test.com")
+        assert mapping.default_owner is None


### PR DESCRIPTION
## Summary
- **Shared utilities** (`migration_utils.py`): Extract common config loading, validation, email domain mapping, and content filters into a reusable module with full test coverage
- **Dry-run mode**: Add `--dry-run` flag to `content_migration.py` and `simple_subscription_migration.py` that prints a validation report (connection info, migration scope, email mapping preview) without executing any migration
- **Standalone `dry_run.py`**: Config-only validation script with optional `--connect` flag to verify server credentials via the SDK

## Test plan
- [x] All 49 tests pass (`pytest tests/ -v`)
- [x] `--dry-run` flag prints report and exits without calling `migration.execute()`
- [x] `dry_run.py` works without the `tableau_migration` SDK installed
- [x] `dry_run.py --connect` gracefully handles missing SDK, validates credentials when SDK present
